### PR TITLE
vertTiltShift: semantic fix, set/getV instead of set/getH

### DIFF
--- a/src/VerticalTiltShifPass.h
+++ b/src/VerticalTiltShifPass.h
@@ -47,10 +47,10 @@ namespace itg
         VerticalTiltShifPass(const ofVec2f& aspect, bool arb);
         
         void render(ofFbo& readFbo, ofFbo& writeFbo);
-        
-        float getH() { return v; }
-        void setH(float val) { v = val; }
-        
+
+        float getV() { return v; }
+        void setV(float val) { v = val; }
+
         float getR() { return r; }
         void setR(float val) { r = val; }
         


### PR DESCRIPTION
maybe pedantic, but was using get/set H, instead of V, assuming because copied from horz tilt shift
