### PR TITLE
Make automatic gui for all used passes

### DIFF
--- a/example/addons.make
+++ b/example/addons.make
@@ -1,1 +1,3 @@
 ofxPostProcessing
+ofxGui
+

--- a/example/example.qbs
+++ b/example/example.qbs
@@ -15,12 +15,11 @@ Project{
             'src/main.cpp',
             'src/ofApp.cpp',
             'src/ofApp.h',
-            'src/testApp.cpp',
-            'src/testApp.h',
         ]
 
         of.addons: [
             'ofxPostProcessing',
+            'ofxGui'
         ]
 
         // additional flags for the project. the of module sets some

--- a/example/src/ofApp.h
+++ b/example/src/ofApp.h
@@ -2,6 +2,7 @@
 
 #include "ofMain.h"
 #include "ofxPostProcessing.h"
+#include "ofxGui.h"
 
 class ofApp : public ofBaseApp
 {
@@ -12,8 +13,6 @@ public:
     void update();
     void draw();
 
-    void keyPressed(int key);
-    
     // scene stuff
     ofxPostProcessing post;
     ofEasyCam cam;
@@ -23,4 +22,13 @@ public:
     vector<ofVec3f> posns;
     vector<ofColor> cols;
     ofVboMesh boxMesh;
+
+    ofParameter<float> spread;
+    ofParameter<float> scale;
+
+    std::map<std::string, RenderPass::Ptr> passes;
+
+    ofxPanel gui;
+
+    void toggleListener(const void * sender, bool & value);
 };


### PR DESCRIPTION
The original example was only showing up to 10 effects, limited by pressing keys 0 to 9. 

By switching to a gui we can show all effects (not only 10), and easily add new ones by instantiating them in one line of code.